### PR TITLE
add support for bstr and fix README/example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+
+[[package]]
 name = "regex-lite"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +348,7 @@ name = "serde-avro-bytes"
 version = "0.1.0"
 dependencies = [
  "apache-avro",
+ "bstr",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ keywords = ["avro", "serde", "bytes"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[example]]
+name = "bstr"
+path = "examples/bstr.rs"
+required-features = ["bstr"]
+
+[features]
+default = []
+bstr = ["dep:bstr"]
+
 [dependencies]
 apache-avro = "0.16.0"
 serde = "1.0.197"
+bstr = { version = "1.9.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ struct Record {
 }
 ```
 
+## Features
+
+* `bstr`: adds support for working with `BString`s which are convenient wrappers for partially valid UTF-8 bytes sequences provided by the [`bst`](https://github.com/BurntSushi/bstr) crate. See [`examples/bstr.rs`](./examples/bstr.rs).

--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ encode its component as "bytes".
 ```rust
 #[derive(Serialize, Deserialize)]
 struct Record {
-    #[serde(with = "avro_bytes::bytes")]
+    #[serde(with = "serde_avro_bytes::bytes")]
     key: Vec<u8>,
-    #[serde(with = "avro_bytes::bytes::option")]
+    #[serde(with = "serde_avro_bytes::bytes::option")]
     key2: Option<Vec<u8>>,
-    #[serde(with = "avro_bytes::hashmap")]
+    #[serde(with = "serde_avro_bytes::hashmap")]
     key3: HashMap<Vec<u8>, Vec<u8>>,
-    #[serde(with = "avro_bytes::btreemap::option")]
+    #[serde(with = "serde_avro_bytes::btreemap::option")]
     key4: Option<BTreeMap<Vec<u8>, Vec<u8>>>,
-    #[serde(with = "avro_bytes::list")]
+    #[serde(with = "serde_avro_bytes::list")]
     key5: Vec<Vec<u8>>,
-    #[serde(with = "avro_bytes::list::option")]
+    #[serde(with = "serde_avro_bytes::list::option")]
     key6: Option<Vec<Vec<u8>>>,
 }
 ```

--- a/examples/bstr.rs
+++ b/examples/bstr.rs
@@ -1,0 +1,152 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    io::Cursor,
+};
+
+use apache_avro::Schema;
+use bstr::BString;
+use serde::{Deserialize, Serialize};
+
+static RECORD: &str = r#"{
+    "name": "Record",
+    "type": "record",
+    "fields": [
+        {
+            "name": "key",
+            "type": "bytes"
+        },
+        {
+            "name": "option",
+            "type": [
+                "null",
+                "bytes"
+            ]
+        },
+        {
+            "name": "list",
+            "type": "array",
+            "items": "bytes"
+        },
+        {
+            "name": "option_list",
+            "type": [
+                "null",
+                {
+                    "type": "array",
+                    "items": "bytes"
+                }
+            ]
+        },
+        {
+            "name": "hashmap",
+            "type": "array",
+            "items": {
+                "name": "Pair",
+                "type": "record",
+                "fields": [
+                    {
+                        "name": "key",
+                        "type": "bytes"
+                    },
+                    {
+                        "name": "value",
+                        "type": "bytes"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "option_hashmap",
+            "type": [
+                "null",
+                {
+                    "type": "array",
+                    "items": "Pair"
+                }
+            ]
+        },
+        {
+            "name": "btreemap",
+            "type": "array",
+            "items": "Pair"
+        },
+        {
+            "name": "option_btreemap",
+            "type": [
+                "null",
+                {
+                    "type": "array",
+                    "items": "Pair"
+                }
+            ]
+        }
+    ]
+}"#;
+
+#[derive(Serialize, Default, Deserialize, PartialEq, Debug)]
+pub struct Record {
+    #[serde(with = "serde_avro_bytes::extra::bstr")]
+    key: BString,
+    #[serde(with = "serde_avro_bytes::extra::bstr::option")]
+    option: Option<BString>,
+
+    #[serde(with = "serde_avro_bytes::extra::bstr::list")]
+    list: Vec<BString>,
+    #[serde(with = "serde_avro_bytes::extra::bstr::list::option")]
+    option_list: Option<Vec<BString>>,
+
+    #[serde(with = "serde_avro_bytes::extra::bstr::hashmap")]
+    hashmap: HashMap<BString, BString>,
+    #[serde(with = "serde_avro_bytes::extra::bstr::hashmap::option")]
+    option_hashmap: Option<HashMap<BString, BString>>,
+
+    #[serde(with = "serde_avro_bytes::extra::bstr::btreemap")]
+    btreemap: BTreeMap<BString, BString>,
+    #[serde(with = "serde_avro_bytes::extra::bstr::btreemap::option")]
+    option_btreemap: Option<BTreeMap<BString, BString>>,
+}
+
+fn avro_encode_decode(schema: &Schema, record: &Record) -> Record {
+    let value = apache_avro::to_value(&record).expect("avro value");
+    let encoded = apache_avro::to_avro_datum(&schema, value).expect("encoded value");
+    let mut reader = Cursor::new(encoded);
+    let value =
+        apache_avro::from_avro_datum(&schema, &mut reader, Some(&schema)).expect("decoded record");
+    apache_avro::from_value::<Record>(&value).expect("record")
+}
+
+static PARTIAL_UTF8: &[u8] = b"hello \xF4\x8F\xBF";
+
+fn main() {
+    let schema = apache_avro::Schema::parse_str(&RECORD).expect("valid avro schema");
+
+    let record = Record::default();
+    assert_eq!(record, avro_encode_decode(&schema, &record));
+
+    let record = Record {
+        key: BString::from(PARTIAL_UTF8),
+        option: Some(BString::from(PARTIAL_UTF8)),
+        list: vec![BString::from(PARTIAL_UTF8), BString::from(PARTIAL_UTF8)],
+        option_list: Some(vec![
+            BString::from(PARTIAL_UTF8),
+            BString::from(PARTIAL_UTF8),
+        ]),
+        hashmap: HashMap::from([
+            (BString::from(PARTIAL_UTF8), BString::from(PARTIAL_UTF8)),
+            (BString::from(PARTIAL_UTF8), BString::from(PARTIAL_UTF8)),
+        ]),
+        option_hashmap: Some(HashMap::from([
+            (BString::from(PARTIAL_UTF8), BString::from(PARTIAL_UTF8)),
+            (BString::from(PARTIAL_UTF8), BString::from(PARTIAL_UTF8)),
+        ])),
+        btreemap: BTreeMap::from([
+            (BString::from(PARTIAL_UTF8), BString::from(PARTIAL_UTF8)),
+            (BString::from(PARTIAL_UTF8), BString::from(PARTIAL_UTF8)),
+        ]),
+        option_btreemap: Some(BTreeMap::from([
+            (BString::from(PARTIAL_UTF8), BString::from(PARTIAL_UTF8)),
+            (BString::from(PARTIAL_UTF8), BString::from(PARTIAL_UTF8)),
+        ])),
+    };
+    assert_eq!(record, avro_encode_decode(&schema, &record));
+}

--- a/examples/idiomatic.rs
+++ b/examples/idiomatic.rs
@@ -2,102 +2,84 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
 
-use playground_avro as avro_bytes;
-
-static SCHEMA: &str = r#"
-{
+static SCHEMA: &str = r#"{
   "name": "Record",
   "type": "record",
   "fields": [
-    {
-      "type": "bytes",
-      "name": "key"
-    },
-    {
-      "type": [
-        "null",
-        "bytes"
-      ],
-      "name": "key2"
-    },
-    {
-      "type": "array",
-      "items": {
-        "type": "record",
-        "name": "Pair1",
-        "fields": [
-          {
-            "name": "key",
-            "type": "bytes"
-          },
-          {
-            "name": "value",
-            "type": "bytes"
-          }
-        ]
+      {
+          "type": "bytes",
+          "name": "key"
       },
-      "name": "key3"
-    },
-    {
-      "type": [
-        "null",
-        {
+      {
+          "type": [
+              "null",
+              "bytes"
+          ],
+          "name": "key2"
+      },
+      {
           "type": "array",
           "items": {
-            "type": "record",
-            "name": "Pair",
-            "fields": [
+              "type": "record",
+              "name": "Pair",
+              "fields": [
+                  {
+                      "name": "key",
+                      "type": "bytes"
+                  },
+                  {
+                      "name": "value",
+                      "type": "bytes"
+                  }
+              ]
+          },
+          "name": "key3"
+      },
+      {
+          "type": [
+              "null",
               {
-                "name": "key",
-                "type": "bytes"
-              },
-              {
-                "name": "value",
-                "type": "bytes"
+                  "type": "array",
+                  "items": "Pair"
               }
-            ]
-          }
-        }
-      ],
-      "name": "key4"
-    },
-    {
-      "type": "array",
-      "items": "bytes",
-      "name": "key5"
-    },
-    {
-      "type": [
-        "null",
-        {
+          ],
+          "name": "key4"
+      },
+      {
           "type": "array",
-          "items": "bytes"
-        }
-      ],
-      "name": "key6"
-    }
+          "items": "bytes",
+          "name": "key5"
+      },
+      {
+          "type": [
+              "null",
+              {
+                  "type": "array",
+                  "items": "bytes"
+              }
+          ],
+          "name": "key6"
+      }
   ]
-}
-"#;
+}"#;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Record {
-    #[serde(with = "avro_bytes::bytes")]
+    #[serde(with = "serde_avro_bytes::bytes")]
     key: Vec<u8>,
-    #[serde(with = "avro_bytes::bytes::option")]
+    #[serde(with = "serde_avro_bytes::bytes::option")]
     key2: Option<Vec<u8>>,
-    #[serde(with = "avro_bytes::hashmap")]
+    #[serde(with = "serde_avro_bytes::hashmap")]
     key3: HashMap<Vec<u8>, Vec<u8>>,
-    #[serde(with = "avro_bytes::btreemap::option")]
+    #[serde(with = "serde_avro_bytes::btreemap::option")]
     key4: Option<BTreeMap<Vec<u8>, Vec<u8>>>,
-    #[serde(with = "avro_bytes::list")]
+    #[serde(with = "serde_avro_bytes::list")]
     key5: Vec<Vec<u8>>,
-    #[serde(with = "avro_bytes::list::option")]
+    #[serde(with = "serde_avro_bytes::list::option")]
     key6: Option<Vec<Vec<u8>>>,
 }
 
 fn main() {
-
     let map = BTreeMap::from([
         (vec![1, 5, 6], vec![7, 8, 9]),
         (vec![10, 11, 12], vec![13, 1, 48]),

--- a/src/avro_bytes/de/bstr.rs
+++ b/src/avro_bytes/de/bstr.rs
@@ -1,0 +1,264 @@
+use core::fmt;
+use std::collections::{BTreeMap, HashMap};
+
+use bstr::BString;
+use serde::{
+    de::{Error, SeqAccess, Visitor},
+    Deserializer,
+};
+
+#[allow(unused)]
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<BString, D::Error> {
+    struct BStringVisitor;
+
+    impl<'de> Visitor<'de> for BStringVisitor {
+        type Value = BString;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a byte string")
+        }
+
+        #[inline]
+        fn visit_seq<V: SeqAccess<'de>>(self, mut seq: V) -> Result<BString, V::Error> {
+            let capacity = seq.size_hint().unwrap_or_default();
+            let mut bytes = Vec::with_capacity(capacity);
+            while let Some(v) = seq.next_element()? {
+                bytes.push(v);
+            }
+            Ok(BString::from(bytes))
+        }
+
+        #[inline]
+        fn visit_bytes<E: Error>(self, value: &[u8]) -> Result<BString, E> {
+            Ok(BString::from(value))
+        }
+
+        #[inline]
+        fn visit_byte_buf<E: Error>(self, value: Vec<u8>) -> Result<BString, E> {
+            Ok(BString::from(value))
+        }
+
+        #[inline]
+        fn visit_str<E: Error>(self, value: &str) -> Result<BString, E> {
+            Ok(BString::from(value))
+        }
+
+        #[inline]
+        fn visit_string<E: Error>(self, value: String) -> Result<BString, E> {
+            Ok(BString::from(value))
+        }
+    }
+
+    deserializer.deserialize_byte_buf(BStringVisitor)
+}
+
+#[allow(unused)]
+pub fn deserialize_option<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<BString>, D::Error> {
+    struct OptionBStringVisitor;
+
+    impl<'de> Visitor<'de> for OptionBStringVisitor {
+        type Value = Option<BString>;
+
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("an optional byte string")
+        }
+
+        #[inline]
+        fn visit_none<E: Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        #[inline]
+        fn visit_some<D: Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            Ok(Some(deserialize(deserializer)?))
+        }
+    }
+
+    deserializer.deserialize_option(OptionBStringVisitor)
+}
+
+#[allow(unused)]
+pub fn deserialize_list<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<BString>, D::Error> {
+    struct VecBStringVisitor;
+
+    impl<'de> Visitor<'de> for VecBStringVisitor {
+        type Value = Vec<BString>;
+
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "a collection of byte strings")
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            use crate::de::map::Bytes;
+
+            let capacity = seq.size_hint().unwrap_or_default();
+            let mut items = Vec::with_capacity(capacity);
+            while let Some(bytes) = seq.next_element::<Bytes>()? {
+                items.push(BString::from(bytes.0));
+            }
+            Ok(items)
+        }
+    }
+
+    deserializer.deserialize_seq(VecBStringVisitor)
+}
+
+#[allow(unused)]
+pub fn deserialize_option_list<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<Vec<BString>>, D::Error> {
+    struct OptionVecBStringVisitor;
+
+    impl<'de> Visitor<'de> for OptionVecBStringVisitor {
+        type Value = Option<Vec<BString>>;
+
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "an optional collection of byte strings")
+        }
+
+        #[inline]
+        fn visit_some<D: Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            Ok(Some(deserialize_list(deserializer)?))
+        }
+
+        #[inline]
+        fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_option(OptionVecBStringVisitor)
+}
+
+#[allow(unused)]
+pub fn deserialize_hashmap<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<HashMap<BString, BString>, D::Error> {
+    struct HashMapBStringVisitor;
+
+    impl<'de> Visitor<'de> for HashMapBStringVisitor {
+        type Value = HashMap<BString, BString>;
+
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "a map of byte strings")
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            use crate::de::map::Pair;
+
+            let capacity = seq.size_hint().unwrap_or_default();
+            let mut items = HashMap::with_capacity(capacity);
+            while let Some(Pair { key, value }) = seq.next_element::<Pair>()? {
+                if let Some(duplicated) = items.insert(BString::new(key.0), BString::new(value.0)) {
+                    return Err(serde::de::Error::custom(format!(
+                        "unexpected duplicate key: `{duplicated}`"
+                    )));
+                }
+            }
+            Ok(items)
+        }
+    }
+
+    deserializer.deserialize_seq(HashMapBStringVisitor)
+}
+
+#[allow(unused)]
+pub fn deserialize_option_hashmap<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<HashMap<BString, BString>>, D::Error> {
+    struct OptionHashMapBStringVisitor;
+
+    impl<'de> Visitor<'de> for OptionHashMapBStringVisitor {
+        type Value = Option<HashMap<BString, BString>>;
+
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "an optional map of byte strings")
+        }
+
+        #[inline]
+        fn visit_some<D: Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            Ok(Some(deserialize_hashmap(deserializer)?))
+        }
+
+        #[inline]
+        fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_option(OptionHashMapBStringVisitor)
+}
+
+#[allow(unused)]
+pub fn deserialize_btreemap<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<BTreeMap<BString, BString>, D::Error> {
+    struct BTreeMapBStringVisitor;
+
+    impl<'de> Visitor<'de> for BTreeMapBStringVisitor {
+        type Value = BTreeMap<BString, BString>;
+
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "a map of byte strings")
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            use crate::de::map::Pair;
+
+            let mut items = BTreeMap::new();
+            while let Some(Pair { key, value }) = seq.next_element::<Pair>()? {
+                if let Some(duplicated) = items.insert(BString::new(key.0), BString::new(value.0)) {
+                    return Err(serde::de::Error::custom(format!(
+                        "unexpected duplicate key: `{duplicated}`"
+                    )));
+                }
+            }
+            Ok(items)
+        }
+    }
+
+    deserializer.deserialize_seq(BTreeMapBStringVisitor)
+}
+
+#[allow(unused)]
+pub fn deserialize_option_btreemap<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<BTreeMap<BString, BString>>, D::Error> {
+    struct OptionBTreeMapBStringVisitor;
+
+    impl<'de> Visitor<'de> for OptionBTreeMapBStringVisitor {
+        type Value = Option<BTreeMap<BString, BString>>;
+
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "an optional map of byte strings")
+        }
+
+        #[inline]
+        fn visit_some<D: Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            Ok(Some(deserialize_btreemap(deserializer)?))
+        }
+
+        #[inline]
+        fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_option(OptionBTreeMapBStringVisitor)
+}

--- a/src/avro_bytes/de/map.rs
+++ b/src/avro_bytes/de/map.rs
@@ -1,13 +1,19 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::Formatter,
+};
+
+use serde::{
+    de::{Error, IgnoredAny, MapAccess, SeqAccess, Visitor},
+    Deserialize, Deserializer,
+};
+
 use crate::avro_bytes::de::bytes::BytesVisitor;
-use serde::de::{Error, IgnoredAny, MapAccess, SeqAccess, Visitor};
-use serde::{Deserialize, Deserializer};
-use std::collections::{BTreeMap, HashMap};
-use std::fmt::Formatter;
 
 #[derive(Debug)]
-struct Pair {
-    key: Bytes,
-    value: Bytes,
+pub(crate) struct Pair {
+    pub(crate) key: Bytes,
+    pub(crate) value: Bytes,
 }
 
 #[derive(Debug)]

--- a/src/avro_bytes/de/map.rs
+++ b/src/avro_bytes/de/map.rs
@@ -63,18 +63,12 @@ impl<'de> Visitor<'de> for VisitorPair {
                 }
             }
         }
-
-        let key = if let Some(x) = key {
-            x
-        } else {
+        let Some(key) = key else {
             return Err(Error::missing_field("key"));
         };
-        let value = if let Some(x) = value {
-            x
-        } else {
+        let Some(value) = value else {
             return Err(Error::missing_field("value"));
         };
-
         Ok(Pair { key, value })
     }
 }

--- a/src/avro_bytes/de/mod.rs
+++ b/src/avro_bytes/de/mod.rs
@@ -1,3 +1,6 @@
 pub mod bytes;
 pub mod list;
 pub mod map;
+
+#[cfg(feature = "bstr")]
+pub mod bstr;

--- a/src/avro_bytes/ser/bytes.rs
+++ b/src/avro_bytes/ser/bytes.rs
@@ -1,29 +1,26 @@
 use serde::{Serialize, Serializer};
 
-pub fn serialize_bytes<S>(v: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_bytes(&v)
-}
-
-pub fn serialize_option_bytes<S>(v: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    match v {
-        None => serializer.serialize_none(),
-        Some(bytes) => serializer.serialize_some(&Bytes(bytes)),
-    }
-}
-
 pub struct Bytes<'a>(pub(crate) &'a [u8]);
 
 impl Serialize for Bytes<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_bytes(self.0)
+    }
+}
+
+pub fn serialize_bytes<S: Serializer>(
+    v: impl AsRef<[u8]>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_bytes(v.as_ref())
+}
+
+pub fn serialize_option_bytes<S: Serializer, T: AsRef<[u8]>>(
+    v: &Option<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match v {
+        None => serializer.serialize_none(),
+        Some(bytes) => serializer.serialize_some(&Bytes(bytes.as_ref())),
     }
 }

--- a/src/avro_bytes/ser/list.rs
+++ b/src/avro_bytes/ser/list.rs
@@ -8,7 +8,7 @@ pub fn serialize_list_bytes<S: Serializer, T: AsRef<[u8]>>(
 ) -> Result<S::Ok, S::Error> {
     let mut seq = serializer.serialize_seq(Some(v.len()))?;
     for x in v {
-        seq.serialize_element(&Bytes(x.as_ref()))?
+        seq.serialize_element(&Bytes(x.as_ref()))?;
     }
     seq.end()
 }

--- a/src/avro_bytes/ser/map.rs
+++ b/src/avro_bytes/ser/map.rs
@@ -1,14 +1,28 @@
-use crate::avro_bytes::ser::pair::Pair;
-use serde::ser::SerializeSeq;
-use serde::Serializer;
 use std::collections::{BTreeMap, HashMap};
 
-pub fn serialize_hashmap<S>(v: &HashMap<Vec<u8>, Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let pairs: PairWrapper = v.into();
-    let pairs = pairs.0;
+use crate::avro_bytes::ser::pair::Pair;
+use serde::{ser::SerializeSeq, Serializer};
+
+pub(crate) struct PairWrapper<'a>(pub(crate) Vec<Pair<'a>>);
+
+impl<'a, K: AsRef<[u8]>, V: AsRef<[u8]>> FromIterator<(&'a K, &'a V)> for PairWrapper<'a> {
+    fn from_iter<T: IntoIterator<Item = (&'a K, &'a V)>>(iter: T) -> Self {
+        Self(
+            iter.into_iter()
+                .map(|(key, value)| Pair {
+                    key: key.as_ref(),
+                    value: value.as_ref(),
+                })
+                .collect(),
+        )
+    }
+}
+
+pub fn serialize_hashmap<S: Serializer, K: AsRef<[u8]>, V: AsRef<[u8]>>(
+    v: &HashMap<K, V>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let pairs = v.iter().collect::<PairWrapper>().0;
     let mut seq = serializer.serialize_seq(Some(pairs.len()))?;
     for pair in pairs {
         seq.serialize_element(&pair)?;
@@ -16,31 +30,21 @@ where
     seq.end()
 }
 
-pub fn serialize_option_hashmap<S>(
-    v: &Option<HashMap<Vec<u8>, Vec<u8>>>,
+pub fn serialize_option_hashmap<S: Serializer, K: AsRef<[u8]>, V: AsRef<[u8]>>(
+    v: &Option<HashMap<K, V>>,
     serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
+) -> Result<S::Ok, S::Error> {
     match v {
         None => serializer.serialize_none(),
-        Some(map) => {
-            let pairs: PairWrapper = map.into();
-            serializer.serialize_some(&pairs.0)
-        }
+        Some(map) => serializer.serialize_some(&map.iter().collect::<PairWrapper>().0),
     }
 }
 
-pub fn serialize_btreemap<S>(
-    v: &BTreeMap<Vec<u8>, Vec<u8>>,
+pub fn serialize_btreemap<S: Serializer, K: AsRef<[u8]>, V: AsRef<[u8]>>(
+    v: &BTreeMap<K, V>,
     serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let pairs: PairWrapper = v.into();
-    let pairs = pairs.0;
+) -> Result<S::Ok, S::Error> {
+    let pairs = v.iter().collect::<PairWrapper>().0;
     let mut seq = serializer.serialize_seq(Some(pairs.len()))?;
     for pair in pairs {
         seq.serialize_element(&pair)?;
@@ -48,46 +52,12 @@ where
     seq.end()
 }
 
-pub fn serialize_option_btreemap<S>(
-    v: &Option<BTreeMap<Vec<u8>, Vec<u8>>>,
+pub fn serialize_option_btreemap<S: Serializer, K: AsRef<[u8]>, V: AsRef<[u8]>>(
+    v: &Option<BTreeMap<K, V>>,
     serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
+) -> Result<S::Ok, S::Error> {
     match v {
         None => serializer.serialize_none(),
-        Some(map) => {
-            let pairs: PairWrapper = map.into();
-            serializer.serialize_some(&pairs.0)
-        }
-    }
-}
-
-struct PairWrapper<'a>(Vec<Pair<'a>>);
-
-impl<'a> From<&'a HashMap<Vec<u8>, Vec<u8>>> for PairWrapper<'a> {
-    fn from(value: &'a HashMap<Vec<u8>, Vec<u8>>) -> Self {
-        let pairs = PairWrapper(
-            value
-                .iter()
-                .map(|(key, value)| Pair { key, value })
-                .collect(),
-        );
-
-        pairs
-    }
-}
-
-impl<'a> From<&'a BTreeMap<Vec<u8>, Vec<u8>>> for PairWrapper<'a> {
-    fn from(value: &'a BTreeMap<Vec<u8>, Vec<u8>>) -> Self {
-        let pairs = PairWrapper(
-            value
-                .iter()
-                .map(|(key, value)| Pair { key, value })
-                .collect(),
-        );
-
-        pairs
+        Some(map) => serializer.serialize_some(&map.iter().collect::<PairWrapper>().0),
     }
 }

--- a/src/avro_bytes/ser/pair.rs
+++ b/src/avro_bytes/ser/pair.rs
@@ -4,8 +4,8 @@ use serde::{Serialize, Serializer};
 
 #[derive(Debug)]
 pub(crate) struct Pair<'a> {
-    pub(crate) key: &'a Vec<u8>,
-    pub(crate) value: &'a Vec<u8>,
+    pub(crate) key: &'a [u8],
+    pub(crate) value: &'a [u8],
 }
 
 impl Serialize for Pair<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod avro_bytes;
 
-use avro_bytes::{ser, de};
+use avro_bytes::{de, ser};
 
 pub mod bytes {
     pub use super::*;
@@ -64,5 +64,79 @@ pub mod list {
         pub use de::list::deserialize_option_list as deserialize;
         #[allow(unused)]
         pub use ser::list::serialize_option_list_bytes as serialize;
+    }
+}
+
+pub mod extra {
+    pub use super::*;
+
+    #[cfg(feature = "bstr")]
+    pub mod bstr {
+        pub use super::*;
+
+        pub use de::bstr::deserialize;
+        pub use ser::bytes::serialize_bytes as serialize;
+
+        pub mod option {
+            pub use super::*;
+
+            #[allow(unused)]
+            pub use de::bstr::deserialize_option as deserialize;
+            #[allow(unused)]
+            pub use ser::bytes::serialize_option_bytes as serialize;
+        }
+
+        pub mod list {
+            pub use super::*;
+
+            #[allow(unused)]
+            pub use de::bstr::deserialize_list as deserialize;
+            #[allow(unused)]
+            pub use ser::list::serialize_list_bytes as serialize;
+
+            pub mod option {
+                pub use super::*;
+
+                #[allow(unused)]
+                pub use de::bstr::deserialize_option_list as deserialize;
+                #[allow(unused)]
+                pub use ser::list::serialize_option_list_bytes as serialize;
+            }
+        }
+
+        pub mod hashmap {
+            pub use super::*;
+
+            #[allow(unused)]
+            pub use de::bstr::deserialize_hashmap as deserialize;
+            #[allow(unused)]
+            pub use ser::map::serialize_hashmap as serialize;
+
+            pub mod option {
+                pub use super::*;
+                #[allow(unused)]
+                pub use de::bstr::deserialize_option_hashmap as deserialize;
+                #[allow(unused)]
+                pub use ser::map::serialize_option_hashmap as serialize;
+            }
+        }
+
+        pub mod btreemap {
+            pub use super::*;
+
+            #[allow(unused)]
+            pub use de::bstr::deserialize_btreemap as deserialize;
+            #[allow(unused)]
+            pub use ser::map::serialize_btreemap as serialize;
+
+            pub mod option {
+                pub use super::*;
+
+                #[allow(unused)]
+                pub use de::bstr::deserialize_option_btreemap as deserialize;
+                #[allow(unused)]
+                pub use ser::map::serialize_option_btreemap as serialize;
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for working with `BString` provided by [bstr](https://github.com/BurntSushi/bstr) as a convenient wrapper around partially valid UTF-8 bytes.